### PR TITLE
fix: skip premium username migration when the username already matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixes
 - fix register command always using BCrypt instead of the selected algo
 - fix different letter case same username migration
+- fix concurrent logins of a renamed premium account throwing out of the PreLoginEvent handler
 
 ### API
 ```diff

--- a/navauth-common/src/main/kotlin/pl/spcode/navauth/common/application/auth/username/UsernameResolutionService.kt
+++ b/navauth-common/src/main/kotlin/pl/spcode/navauth/common/application/auth/username/UsernameResolutionService.kt
@@ -41,15 +41,22 @@ constructor(private val userService: UserService, private val profileService: Pr
     if (existingUserIgnoreCase == null && isPremiumNickname) {
       val userByMojangUuid = userService.findUserByMojangUuid(correspondingPremiumProfile.uuid)
       if (userByMojangUuid != null) {
-        // user with the same mojang uuid exists, but with different nickname
-        try {
-          userService.migrateUsername(userByMojangUuid, correspondingPremiumProfile.name)
-        } catch (e: UsernameAlreadyTakenException) {
-          return failure(
-            UsernameResFailureReason.UsernameMigrationFailedUsernameAlreadyTaken(
-              correspondingPremiumProfile.name.value
+        // user with the same mojang uuid exists, but usually with a different nickname.
+        // The stored username can already be the profile one when a concurrent login for the same
+        // account committed the migration between the caller's lookup and this branch: then
+        // `existingUserIgnoreCase` is a stale null while the row is already migrated. There is
+        // nothing left to migrate, and asking UserService to do it anyway would throw
+        // IllegalArgumentException out of the login pipeline.
+        if (userByMojangUuid.username != correspondingPremiumProfile.name) {
+          try {
+            userService.migrateUsername(userByMojangUuid, correspondingPremiumProfile.name)
+          } catch (e: UsernameAlreadyTakenException) {
+            return failure(
+              UsernameResFailureReason.UsernameMigrationFailedUsernameAlreadyTaken(
+                correspondingPremiumProfile.name.value
+              )
             )
-          )
+          }
         }
         if (connUsername != correspondingPremiumProfile.name) {
           return failure(

--- a/navauth-common/src/test/kotlin/integration/auth/UsernameResolutionServiceIntegrationTests.kt
+++ b/navauth-common/src/test/kotlin/integration/auth/UsernameResolutionServiceIntegrationTests.kt
@@ -22,6 +22,11 @@ import com.google.inject.Inject
 import extension.app.UsernameResolutionTestExtension
 import fake.FakeProfileService
 import java.util.UUID
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -247,6 +252,80 @@ class UsernameResolutionServiceIntegrationTests {
       ),
       result,
     )
+  }
+
+  @Test
+  fun `premium user already renamed by a concurrent login resolves without failing`() {
+    val mojangId = MojangId(UUID.randomUUID())
+    val userUuid = UserUuid(UUID.randomUUID())
+    val username = Username(generateRandomString(10))
+    // State left behind by a login that already committed the rename.
+    userRepository.save(User.premium(userUuid, username, mojangId))
+    fakeProfileService.addProfile(username, MojangProfile(mojangId, username))
+
+    // The caller looked the user up before that rename was committed, so it hands over a stale
+    // null while the row already carries the Mojang username.
+    val result = usernameResolutionService.resolveUsernameConflicts(username, null)
+
+    assertEquals(
+      UsernameResResult.Success(
+        EncryptionType.ENFORCE_PREMIUM,
+        PostUsernameResolutionState.PREMIUM_USERNAME_MIGRATED,
+      ),
+      result,
+    )
+    assertEquals(username, userRepository.findByUserUuid(userUuid)!!.username)
+  }
+
+  @Test
+  fun `concurrent logins of a renamed premium user never fail the resolution`() {
+    val executor = Executors.newFixedThreadPool(2)
+    try {
+      repeat(32) {
+        val mojangId = MojangId(UUID.randomUUID())
+        val userUuid = UserUuid(UUID.randomUUID())
+        val oldUsername = Username(generateRandomString(10))
+        val newUsername = Username(generateRandomString(10))
+        userRepository.save(User.premium(userUuid, oldUsername, mojangId))
+        fakeProfileService.addProfile(newUsername, MojangProfile(mojangId, newUsername))
+
+        // Two PreLoginEvents racing for the same account. Both read the pre-rename state, then
+        // the second one resolves after the first has committed the migration, so it works on a
+        // stale null while the row already carries the new username. The latch only makes that
+        // interleaving deterministic; on a live proxy it is what two reconnects milliseconds
+        // apart produce.
+        val bothLookedUp = CyclicBarrier(2)
+        val firstResolved = CountDownLatch(1)
+        val logins =
+          (1..2).map { login ->
+            executor.submit(
+              Callable {
+                val existingUser = userService.findUserByUsernameIgnoreCase(newUsername.value)
+                bothLookedUp.await(20, TimeUnit.SECONDS)
+                if (login == 2) check(firstResolved.await(20, TimeUnit.SECONDS))
+                try {
+                  usernameResolutionService.resolveUsernameConflicts(newUsername, existingUser)
+                } finally {
+                  if (login == 1) firstResolved.countDown()
+                }
+              }
+            )
+          }
+
+        logins.forEach { login ->
+          assertEquals(
+            UsernameResResult.Success(
+              EncryptionType.ENFORCE_PREMIUM,
+              PostUsernameResolutionState.PREMIUM_USERNAME_MIGRATED,
+            ),
+            login.get(30, TimeUnit.SECONDS),
+          )
+        }
+        assertEquals(newUsername, userRepository.findByUserUuid(userUuid)!!.username)
+      }
+    } finally {
+      executor.shutdownNow()
+    }
   }
 
   @Test


### PR DESCRIPTION
## Problem

When several logins of the same **renamed premium account** overlap, they all read the pre-rename state, so `existingUserIgnoreCase` is `null` for each of them. The first connection commits the username migration; the later ones then find that row — *already carrying the Mojang username* — through `findUserByMojangUuid`, and ask for the very same migration again. `migrateUsernameNoTx` rejects it, and the exception escapes the `PreLoginEvent` handler:

```
ERROR: Couldn't pass PreLoginEvent to navauth
java.sql.SQLException: OrmLite SQL transaction failed
	at ...TransactionServiceImpl$inTransaction$1.call(TransactionServiceImpl.kt:36)
	at ...UserService.migrateUsername-NOTGgSg(UserService.kt:171)
	at ...UsernameResolutionService.resolveUsernameConflicts-xYvRu8A(UsernameResolutionService.kt:46)
	at ...LoginListeners.onPreLogin(LoginListeners.kt:84)
Caused by: java.lang.IllegalArgumentException: username cannot be the same
	at ...UserService.migrateUsernameNoTx-NOTGgSg(UserService.kt:217)
```

`resolveUsernameConflicts` catches only `UsernameAlreadyTakenException`, so this one propagates. NavAuth still fails closed — the handshake session is never created, and the `onPostLogin` / `PlayerChooseInitialServer` / `OnServerConnect` guards disconnect the player with *"Auth session expired, please try again"* — but a premium player who renamed and reconnects quickly can get stuck in a kick loop, and `onGameProfile` additionally throws an NPE at `LoginListeners.kt:187`.

This was first observed on a live proxy: one occurrence in ~60 logins, right after three reconnects of the same account within 13 seconds.

## Fix

Migrate only when the stored username actually differs from the Mojang profile name. The guard mirrors the exact condition `migrateUsernameNoTx` throws on (`Username` is a value class over `String`, so the comparison is case-sensitive and a letter-case rename is still migrated), and it leaves the documented `UserService` contract untouched.

## Tests

Two cases added to `UsernameResolutionServiceIntegrationTests`:

- `premium user already renamed by a concurrent login resolves without failing` — resolves with the stale `null` against an already-migrated row. Deterministic, and it reproduces the stack trace above exactly.
- `concurrent logins of a renamed premium user never fail the resolution` — two real threads over 32 rounds, both reading the pre-rename state and the second resolving after the first has committed. A latch makes that interleaving deterministic.

Both fail on `main` and pass with the fix. Full `navauth-common` suite: 114 tests, 0 failures. `spotlessCheck` is green.

The scenario was also verified end to end outside this repo, running the built plugin on a real headless Velocity with a seeded H2 database and eight simultaneous logins of a renamed premium account: the errors above appear on `main` and are gone with this change.
